### PR TITLE
Fix/fetcher no content

### DIFF
--- a/lib/fetcher.ts
+++ b/lib/fetcher.ts
@@ -5,8 +5,8 @@ export type EmptyJSON = Record<string, never>;
  * REST APIを呼び出す
  * "Content-Type": "application/json"はデフォルトで設定される(オプションで上書き可能)
  * @param url - APIエンドポイントのURL
- * @param options - Fetch APIオプション
- * @returns JSONレスポンスを解決する、またはエラーで拒否されるPromise
+ * @param options - Fetch APIオプション。
+ * @returns JSONレスポンスを解決する、またはエラーで拒否されるPromise。204 No Contentの場合はvoidを返す
  */
 export async function fetcher<T>(
   url: string,


### PR DESCRIPTION
This pull request introduces improvements to the `fetcher.ts` utility, mainly to enhance type safety and correctly handle HTTP 204 No Content responses.

Type safety and response handling:

* Added a new type alias `EmptyJSON` to represent an empty JSON object, improving type clarity in API responses.
* Updated the `fetcher` function to return `undefined` when an HTTP 204 No Content response is received, ensuring correct handling of endpoints that do not return a body.