### PR TITLE
feat: 🎸 Responseなしエンドポイントのvoid型を定義

### DIFF
--- a/types/api/auth/index.ts
+++ b/types/api/auth/index.ts
@@ -2,5 +2,6 @@ export type {
   AuthRegisterPostRequest,
   AuthRegisterPostResponse,
 } from "./register";
-export type { AuthLoginPostRequest } from "./login";
+export type { AuthLoginPostRequest, AuthLoginPostResponse } from "./login";
+export type { AuthLogoutPostResponse } from "./logout";
 export type { AuthSessionGetResponse } from "./session";

--- a/types/api/auth/login.ts
+++ b/types/api/auth/login.ts
@@ -4,3 +4,5 @@ export type AuthLoginPostRequest = {
   email: Email;
   password: Password;
 };
+
+export type AuthLoginPostResponse = void;

--- a/types/api/auth/logout.ts
+++ b/types/api/auth/logout.ts
@@ -1,0 +1,1 @@
+export type AuthLogoutPostResponse = void;

--- a/types/api/buyers/index.ts
+++ b/types/api/buyers/index.ts
@@ -2,6 +2,7 @@ export type {
   BuyersMeGetResponse,
   BuyersMePatchRequest,
   BuyersMePatchResponse,
+  BuyersMeDeleteResponse,
 } from "./me";
 export type {
   BuyersMeReportsGetResponse,

--- a/types/api/buyers/me.ts
+++ b/types/api/buyers/me.ts
@@ -5,3 +5,5 @@ export type BuyersMeGetResponse = Buyer;
 export type BuyersMePatchRequest = Partial<BuyerSetting>;
 
 export type BuyersMePatchResponse = Buyer;
+
+export type BuyersMeDeleteResponse = void;

--- a/types/api/stores/index.ts
+++ b/types/api/stores/index.ts
@@ -2,6 +2,7 @@ export type {
   StoresMeGetResponse,
   StoresMePatchRequest,
   StoresMePatchResponse,
+  StoresMeDeleteResponse,
 } from "./me";
 export type { StoresMeReportsGetResponse } from "./me-reports";
 export type {
@@ -13,6 +14,7 @@ export type {
   StoresMeItemsDetailsGetResponse,
   StoresMeItemsDetailsPatchRequest,
   StoresMeItemsDetailsPatchResponse,
+  StoresMeItemsDetailsDeleteResponse,
 } from "./me-items-item-id";
 export type { StoresDetailsGetResponse } from "./store-id";
 export type { StoresDetailsItemsGetResponse } from "./store-id-items";

--- a/types/api/stores/me-items-item-id.ts
+++ b/types/api/stores/me-items-item-id.ts
@@ -8,3 +8,5 @@ export type StoresMeItemsDetailsPatchRequest = Partial<
 >;
 
 export type StoresMeItemsDetailsPatchResponse = ItemDetailForStore;
+
+export type StoresMeItemsDetailsDeleteResponse = void;

--- a/types/api/stores/me.ts
+++ b/types/api/stores/me.ts
@@ -5,3 +5,5 @@ export type StoresMeGetResponse = Store;
 export type StoresMePatchRequest = Partial<StoreSetting>;
 
 export type StoresMePatchResponse = Store;
+
+export type StoresMeDeleteResponse = void;


### PR DESCRIPTION
## 概要
レスポンスボディを返さないエンドポイントについて、`fetcher<unknown>` をやめ、`types/api` で `void` レスポンス型を明示するように統一しました。  

## 変更内容
- `types/api` に `void` レスポンス型を追加
- 追加した型
  - `AuthLoginPostResponse = void`
  - `AuthLogoutPostResponse = void`（`types/api/auth/logout.ts` 新規）
  - `BuyersMeDeleteResponse = void`
  - `StoresMeDeleteResponse = void`
  - `StoresMeItemsDetailsDeleteResponse = void`