### PR TITLE
ローダーを2つ追加

### DIFF
--- a/components/loader/SquareMove2.module.css
+++ b/components/loader/SquareMove2.module.css
@@ -1,0 +1,78 @@
+.square-move-2 {
+  --size: 24px;
+  --color: currentColor;
+  --animation-timing-function: linear;
+  --animation-duration: 2s;
+  position: relative;
+  width: var(--size);
+  height: var(--size);
+}
+
+.square-move-2::before,
+.square-move-2::after {
+  content: "";
+  position: absolute;
+  width: 50%;
+  height: 50%;
+  background-color: var(--color);
+}
+
+.square-move-2::before {
+  top: 0;
+  left: 0;
+  transform: translate(0%, 0%);
+  animation: var(--animation-timing-function) var(--animation-duration) infinite
+    square-move-2-animation-before;
+}
+
+.square-move-2::after {
+  right: 0;
+  bottom: 0;
+  transform: translate(0%, 0%);
+  animation: var(--animation-timing-function) var(--animation-duration) infinite
+    square-move-2-animation-after;
+}
+
+@keyframes square-move-2-animation-before {
+  0% {
+    transform: translate(0%, 0%);
+  }
+
+  25% {
+    transform: translate(100%, 0%);
+  }
+
+  50% {
+    transform: translate(100%, 100%);
+  }
+
+  75% {
+    transform: translate(0%, 100%);
+  }
+
+  100% {
+    transform: translate(0%, 0%);
+  }
+}
+
+@keyframes square-move-2-animation-after {
+  0% {
+    transform: translate(0%, 0%);
+  }
+
+  25% {
+    transform: translate(-100%, 0%);
+  }
+
+  50% {
+    transform: translate(-100%, -100%);
+  }
+
+  75% {
+    transform: translate(0%, -100%);
+  }
+
+  100% {
+    transform: translate(0%, 0%);
+  }
+}

--- a/components/loader/SquareMove2.tsx
+++ b/components/loader/SquareMove2.tsx
@@ -1,0 +1,15 @@
+import Style from "./SquareMove2.module.css";
+import type { ILoader } from "./types";
+
+export function SquareMove2({ color, size }: ILoader) {
+  return (
+    <div
+      className={Style["square-move-2"]}
+      style={{
+        color: color,
+        width: size,
+        height: size,
+      }}
+    ></div>
+  );
+}

--- a/components/loader/SquareSpin2.module.css
+++ b/components/loader/SquareSpin2.module.css
@@ -1,0 +1,51 @@
+.square-spin-2 {
+  --size: 24px;
+  --stroke-width: calc(var(--size) / 6);
+  --color: currentColor;
+  --animation-timing-function: linear;
+  --animation-duration: 2s;
+  width: var(--size);
+  height: var(--size);
+  background-image:
+    radial-gradient(
+      circle at var(--stroke-width) var(--stroke-width),
+      var(--color) 0%,
+      var(--color) var(--stroke-width),
+      transparent var(--stroke-width),
+      transparent 100%
+    ),
+    radial-gradient(
+      circle at calc(100% - var(--stroke-width)) var(--stroke-width),
+      var(--color) 0%,
+      var(--color) var(--stroke-width),
+      transparent var(--stroke-width),
+      transparent 100%
+    ),
+    radial-gradient(
+      circle at calc(100% - var(--stroke-width))
+        calc(100% - var(--stroke-width)),
+      var(--color) 0%,
+      var(--color) var(--stroke-width),
+      transparent var(--stroke-width),
+      transparent 100%
+    ),
+    radial-gradient(
+      circle at var(--stroke-width) calc(100% - var(--stroke-width)),
+      var(--color) 0%,
+      var(--color) var(--stroke-width),
+      transparent var(--stroke-width),
+      transparent 100%
+    );
+  animation: var(--animation-timing-function) var(--animation-duration) infinite
+    square-spin-2-animation;
+}
+
+@keyframes square-spin-2-animation {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/components/loader/SquareSpin2.tsx
+++ b/components/loader/SquareSpin2.tsx
@@ -1,0 +1,15 @@
+import Style from "./SquareSpin2.module.css";
+import type { ILoader } from "./types";
+
+export function SquareSpin2({ color, size }: ILoader) {
+  return (
+    <div
+      className={Style["square-spin-2"]}
+      style={{
+        color: color,
+        width: size,
+        height: size,
+      }}
+    ></div>
+  );
+}

--- a/components/loader/index.ts
+++ b/components/loader/index.ts
@@ -1,0 +1,2 @@
+export * from "./SquareMove2";
+export * from "./SquareSpin2";

--- a/components/loader/types.ts
+++ b/components/loader/types.ts
@@ -1,0 +1,6 @@
+interface ILoader {
+  color: string;
+  size: string;
+}
+
+export type { ILoader };


### PR DESCRIPTION
This pull request adds two new animated loader components, `SquareMove2` and `SquareSpin2`, to the `components/loader` directory. Both loaders are implemented with customizable color and size props, reusable TypeScript types, and dedicated CSS modules for animation and styling. The new loaders are also exported from the loader index for easy import elsewhere in the project.

**New Loader Components:**

* Added `SquareMove2` component with customizable color and size, using a new CSS animation for moving squares (`SquareMove2.tsx`, `SquareMove2.module.css`). [[1]](diffhunk://#diff-84354b443d3aded541972822522faa091d73dbdb5a68b608855df5b2122ca89bR1-R15) [[2]](diffhunk://#diff-7902bcd83aeda3560305384ae3a69b60673d24bfbb05f07388ec10a7f08ff2dcR1-R78)
* Added `SquareSpin2` component with customizable color and size, using a new CSS animation for spinning squares (`SquareSpin2.tsx`, `SquareSpin2.module.css`). [[1]](diffhunk://#diff-e15b25c7e19c2f3e0c75629b98adee7545fd609832aa56979766cbb77ddad304R1-R15) [[2]](diffhunk://#diff-3ff52beffcb2ee5d3497d0cfecfca5f1ddf2e88223d0e7db5973a62eea877768R1-R51)

**Type and Export Updates:**

* Introduced a shared `ILoader` TypeScript interface for loader props (`types.ts`).
* Updated the loader index to export the new components (`index.ts`).